### PR TITLE
fix: examples, mac wasm

### DIFF
--- a/examples/3d/main.go
+++ b/examples/3d/main.go
@@ -1,18 +1,18 @@
 package main
 
 import (
-	"fmt"
-	"log"
 	"embed"
+	"flag"
+	"fmt"
 	"image"
 	"image/draw"
 	_ "image/png"
-	"time"
+	"log"
+	"math"
+	"os"
 	"runtime"
 	"runtime/pprof"
-	"flag"
-	"os"
-	"math"
+	"time"
 
 	"github.com/unitoftime/glitch"
 	"github.com/unitoftime/glitch/shaders"
@@ -23,6 +23,7 @@ var memprofile = flag.String("memprofile", "", "write memory profile to `file`")
 
 //go:embed gopher.png
 var f embed.FS
+
 func loadImage(path string) (*image.NRGBA, error) {
 	file, err := f.Open(path)
 	if err != nil {
@@ -63,7 +64,7 @@ func main() {
 			log.Fatal("could not create memory profile: ", err)
 		}
 		defer f.Close() // error handling omitted for example
-		runtime.GC() // get up-to-date statistics
+		runtime.GC()    // get up-to-date statistics
 		if err := pprof.WriteHeapProfile(f); err != nil {
 			log.Fatal("could not write memory profile: ", err)
 		}
@@ -72,18 +73,24 @@ func main() {
 
 func runGame() {
 	win, err := glitch.NewWindow(1920, 1080, "Glitch", glitch.WindowConfig{
-		Vsync: true,
+		Vsync:   true,
 		Samples: 8,
 	})
-	if err != nil { panic(err) }
+	if err != nil {
+		panic(err)
+	}
 
 	shader, err := glitch.NewShader(shaders.SpriteShader)
-	if err != nil { panic(err) }
+	if err != nil {
+		panic(err)
+	}
 
 	pass := glitch.NewRenderPass(shader)
 
 	diffuseShader, err := glitch.NewShader(shaders.DiffuseShader)
-	if err != nil { panic(err) }
+	if err != nil {
+		panic(err)
+	}
 	diffusePass := glitch.NewRenderPass(diffuseShader)
 	diffusePass.DepthTest = true
 
@@ -102,9 +109,11 @@ func runGame() {
 
 	// Text
 	atlas, err := glitch.DefaultAtlas()
-	if err != nil { panic(err) }
+	if err != nil {
+		panic(err)
+	}
 
-	text := atlas.Text("hello world")
+	text := atlas.Text("hello world", 1)
 
 	cube := glitch.NewModel(glitch.NewCubeMesh(50), glitch.DefaultMaterial())
 
@@ -142,7 +151,7 @@ func runGame() {
 		mat.Scale(0.25, 0.25, 1.0).Translate(100, 100, 0)
 
 		pass.SetLayer(0)
-		manSprite.DrawColorMask(pass, mat, glitch.RGBA{1, 1, 1, 1})
+		manSprite.DrawColorMask(pass, mat, glitch.RGBA{R: 1, G: 1, B: 1, A: 1})
 		quadModel.Draw(pass, glitch.Mat4Ident)
 
 		cubeMat := glitch.Mat4Ident
@@ -153,9 +162,9 @@ func runGame() {
 		mat = glitch.Mat4Ident
 		mat.Translate(0, 0, 0)
 		text.Set(fmt.Sprintf("%2.2f ms", 1000*dt.Seconds()))
-		text.DrawColorMask(pass, mat, glitch.RGBA{1.0, 1.0, 0.0, 1.0})
+		text.DrawColorMask(pass, mat, glitch.RGBA{R: 1.0, G: 1.0, B: 0.0, A: 1.0})
 
-		glitch.Clear(win, glitch.RGBA{0.1, 0.2, 0.3, 1.0})
+		glitch.Clear(win, glitch.RGBA{R: 0.1, G: 0.2, B: 0.3, A: 1.0})
 
 		pass.SetUniform("projection", camera.Projection)
 		pass.SetUniform("view", camera.View)
@@ -165,7 +174,7 @@ func runGame() {
 		diffusePass.SetUniform("view", pCam.View)
 		// diffusePass.SetUniform("model", cubeMat)
 
-		diffusePass.SetUniform("viewPos", pCam.Position);
+		diffusePass.SetUniform("viewPos", pCam.Position)
 
 		diffusePass.SetUniform("material.ambient", glitch.Vec3{1, 0.5, 0.31})
 		diffusePass.SetUniform("material.diffuse", glitch.Vec3{1, 0.5, 0.31})

--- a/examples/frame/main.go
+++ b/examples/frame/main.go
@@ -1,13 +1,13 @@
 package main
 
 import (
-	"fmt"
 	"embed"
+	"fmt"
 	"image"
 	"image/draw"
 	_ "image/png"
-	"time"
 	"math/rand"
+	"time"
 
 	"github.com/unitoftime/glitch"
 	"github.com/unitoftime/glitch/shaders"
@@ -15,6 +15,7 @@ import (
 
 //go:embed gopher.png
 var f embed.FS
+
 func loadImage(path string) (*image.NRGBA, error) {
 	file, err := f.Open(path)
 	if err != nil {
@@ -38,10 +39,14 @@ func runGame() {
 	win, err := glitch.NewWindow(1920, 1080, "Glitch - Framebuffer", glitch.WindowConfig{
 		Vsync: false,
 	})
-	if err != nil { panic(err) }
+	if err != nil {
+		panic(err)
+	}
 
 	shader, err := glitch.NewShader(shaders.SpriteShader)
-	if err != nil { panic(err) }
+	if err != nil {
+		panic(err)
+	}
 
 	pass := glitch.NewRenderPass(shader)
 	windowPass := glitch.NewRenderPass(shader)
@@ -67,9 +72,11 @@ func runGame() {
 
 	// Text
 	atlas, err := glitch.DefaultAtlas()
-	if err != nil { panic(err) }
+	if err != nil {
+		panic(err)
+	}
 
-	text := atlas.Text("hello world")
+	text := atlas.Text("hello world", 1)
 
 	fmt.Println(win.Bounds())
 	frame := glitch.NewFrame(win.Bounds(), false)
@@ -114,9 +121,9 @@ func runGame() {
 		mat.Translate(0, 0, 0)
 		pass.SetLayer(0)
 		text.Set(fmt.Sprintf("%2.2f ms", 1000*dt.Seconds()))
-		text.DrawColorMask(pass, mat, glitch.RGBA{1.0, 1.0, 0.0, 1.0})
+		text.DrawColorMask(pass, mat, glitch.RGBA{R: 1.0, G: 1.0, B: 0.0, A: 1.0})
 
-		glitch.Clear(frame, glitch.RGBA{1, 1, 1, 1})
+		glitch.Clear(frame, glitch.RGBA{R: 1, G: 1, B: 1, A: 1})
 
 		pass.SetUniform("projection", camera.Projection)
 		pass.SetUniform("view", camera.View)
@@ -127,7 +134,7 @@ func runGame() {
 		windowPass.SetUniform("view", glitch.Mat4Ident)
 		frame.Draw(windowPass, glitch.Mat4Ident)
 
-		glitch.Clear(win, glitch.RGBA{0.1, 0.2, 0.3, 1.0})
+		glitch.Clear(win, glitch.RGBA{R: 0.1, G: 0.2, B: 0.3, A: 1.0})
 		windowPass.Draw(win)
 		win.Update()
 
@@ -139,14 +146,15 @@ func runGame() {
 
 type Man struct {
 	position, velocity glitch.Vec2
-	color glitch.RGBA
-	layer int8
+	color              glitch.RGBA
+	layer              int8
 }
+
 func NewMan() Man {
 	colors := []glitch.RGBA{
-		glitch.RGBA{1.0, 0, 0, 1.0},
-		glitch.RGBA{0, 1.0, 0, 1.0},
-		glitch.RGBA{0, 0, 1.0, 1.0},
+		glitch.RGBA{R: 1.0, G: 0, B: 0, A: 1.0},
+		glitch.RGBA{R: 0, G: 1.0, B: 0, A: 1.0},
+		glitch.RGBA{R: 0, G: 0, B: 1.0, A: 1.0},
 	}
 	randIndex := rand.Intn(len(colors))
 	vScale := 5.0
@@ -154,9 +162,9 @@ func NewMan() Man {
 		// position: mgl32.Vec2{100, 100},
 		// position: mgl32.Vec2{float32(float64(width/2) * rand.Float64()),
 		// 	float32(float64(height/2) * rand.Float64())},
-		position: glitch.Vec2{1920/2, 1080/2},
-		velocity: glitch.Vec2{float64(2*vScale * (rand.Float64()-0.5)),
-			float64(2*vScale * (rand.Float64()-0.5))},
+		position: glitch.Vec2{1920 / 2, 1080 / 2},
+		velocity: glitch.Vec2{float64(2 * vScale * (rand.Float64() - 0.5)),
+			float64(2 * vScale * (rand.Float64() - 0.5))},
 		color: colors[randIndex],
 		layer: int8(randIndex) + 1,
 	}

--- a/examples/gophermark/main.go
+++ b/examples/gophermark/main.go
@@ -25,6 +25,7 @@ var memprofile = flag.String("memprofile", "", "write memory profile to `file`")
 
 //go:embed gopher.png
 var f embed.FS
+
 func loadImage(path string) (*image.NRGBA, error) {
 	file, err := f.Open(path)
 	if err != nil {
@@ -64,7 +65,7 @@ func main() {
 			log.Fatal("could not create memory profile: ", err)
 		}
 		defer f.Close() // error handling omitted for example
-		runtime.GC() // get up-to-date statistics
+		runtime.GC()    // get up-to-date statistics
 		if err := pprof.WriteHeapProfile(f); err != nil {
 			log.Fatal("could not write memory profile: ", err)
 		}
@@ -75,10 +76,14 @@ func runGame() {
 	win, err := glitch.NewWindow(1920, 1080, "Glitch - Gophermark", glitch.WindowConfig{
 		Vsync: false,
 	})
-	if err != nil { panic(err) }
+	if err != nil {
+		panic(err)
+	}
 
 	shader, err := glitch.NewShader(shaders.SpriteShader)
-	if err != nil { panic(err) }
+	if err != nil {
+		panic(err)
+	}
 
 	pass := glitch.NewRenderPass(shader)
 	pass.DepthTest = true
@@ -96,12 +101,14 @@ func runGame() {
 		man[i] = NewMan()
 	}
 
-	w := float64(160.0)/4
-	h := float64(200.0)/4
+	w := float64(160.0) / 4
+	h := float64(200.0) / 4
 
 	// Text
 	atlas, err := glitch.DefaultAtlas()
-	if err != nil { panic(err) }
+	if err != nil {
+		panic(err)
+	}
 
 	text := atlas.Text("", 1)
 
@@ -149,9 +156,9 @@ func runGame() {
 		if counter == 0 {
 			text.Clear()
 			text.Set(fmt.Sprintf("%2.2f (%2.2f, %2.2f) ms",
-				1000 * dt.Seconds(),
-				1000 * min.Seconds(),
-				1000 * max.Seconds()))
+				1000*dt.Seconds(),
+				1000*min.Seconds(),
+				1000*max.Seconds()))
 			min = 100000000000
 			max = 0
 		}
@@ -169,7 +176,7 @@ func runGame() {
 		}
 		// geom.Draw(pass, glitch.Mat4Ident)
 
-		glitch.Clear(win, glitch.RGBA{0.1, 0.2, 0.3, 1.0})
+		glitch.Clear(win, glitch.RGBA{R: 0.1, G: 0.2, B: 0.3, A: 1.0})
 
 		pass.SetCamera2D(camera)
 		pass.Draw(win)
@@ -179,22 +186,27 @@ func runGame() {
 		dt = time.Since(start)
 
 		// dt = time.Since(start)
-		if dt > max { max = dt }
-		if dt < min { min = dt }
+		if dt > max {
+			max = dt
+		}
+		if dt < min {
+			min = dt
+		}
 		// fmt.Println(dt.Seconds() * 1000)
 	}
 }
 
 type Man struct {
 	position, velocity glitch.Vec2
-	color glitch.RGBA
-	layer uint8
+	color              glitch.RGBA
+	layer              uint8
 }
+
 func NewMan() Man {
 	colors := []glitch.RGBA{
-		glitch.RGBA{1.0, 0, 0, 1.0},
-		glitch.RGBA{0, 1.0, 0, 1.0},
-		glitch.RGBA{0, 0, 1.0, 1.0},
+		glitch.RGBA{R: 1.0, G: 0, B: 0, A: 1.0},
+		glitch.RGBA{R: 0, G: 1.0, B: 0, A: 1.0},
+		glitch.RGBA{R: 0, G: 0, B: 1.0, A: 1.0},
 	}
 	randIndex := rand.Intn(len(colors))
 	vScale := 5.0
@@ -202,9 +214,9 @@ func NewMan() Man {
 		// position: mgl32.Vec2{100, 100},
 		// position: mgl32.Vec2{float32(float64(width/2) * rand.Float64()),
 		// 	float32(float64(height/2) * rand.Float64())},
-		position: glitch.Vec2{1920/2, 1080/2},
-		velocity: glitch.Vec2{float64(2*vScale * (rand.Float64()-0.5)),
-			float64(2*vScale * (rand.Float64()-0.5))},
+		position: glitch.Vec2{1920 / 2, 1080 / 2},
+		velocity: glitch.Vec2{float64(2 * vScale * (rand.Float64() - 0.5)),
+			float64(2 * vScale * (rand.Float64() - 0.5))},
 		color: colors[randIndex],
 		layer: uint8(randIndex) + 1,
 	}

--- a/examples/graph/main.go
+++ b/examples/graph/main.go
@@ -13,7 +13,9 @@ import (
 )
 
 func check(err error) {
-	if err != nil { panic(err) }
+	if err != nil {
+		panic(err)
+	}
 }
 
 func main() {
@@ -23,19 +25,21 @@ func main() {
 
 func runGame() {
 	win, err := glitch.NewWindow(1920, 1080, "Glitch - Graph Demo", glitch.WindowConfig{
-		Vsync: true,
+		Vsync:   true,
 		Samples: 4,
 	})
 	check(err)
 
 	shader, err := glitch.NewShader(shaders.SpriteShader)
-	if err != nil { panic(err) }
+	if err != nil {
+		panic(err)
+	}
 
 	pass := glitch.NewRenderPass(shader)
 
 	dat := make([]glitch.Vec2, 0)
 	for i := 0; i < 1000; i++ {
-		dat = append(dat, glitch.Vec2{float64(i)/100.0, float64(math.Sin(float64(i) / 100.0))})
+		dat = append(dat, glitch.Vec2{float64(i) / 100.0, float64(math.Sin(float64(i) / 100.0))})
 	}
 
 	// lightBlue := glitch.RGBA{0x8a, 0xeb, 0xf1, 0xff}
@@ -45,7 +49,7 @@ func runGame() {
 	// rect := glitch.R(0 + pad, 0 + pad, 1920 - pad, 1080 - pad)
 	// rect := glitch.R(0, 0, 1, 1)
 	rect := win.Bounds()
-	rect = glitch.R(rect.Min[0], rect.Min[1], rect.Min[0] + 500, rect.Min[1] + 500)
+	rect = glitch.R(rect.Min[0], rect.Min[1], rect.Min[0]+500, rect.Min[1]+500)
 
 	graph := graph.NewGraph(rect)
 

--- a/examples/idea.go
+++ b/examples/idea.go
@@ -1,4 +1,5 @@
 package main
+
 /*
 
 // Sorting

--- a/examples/imgui/main.go
+++ b/examples/imgui/main.go
@@ -16,7 +16,9 @@ import (
 )
 
 func check(err error) {
-	if err != nil { panic(err) }
+	if err != nil {
+		panic(err)
+	}
 }
 
 func main() {
@@ -26,7 +28,7 @@ func main() {
 
 func runGame() {
 	win, err := glitch.NewWindow(1920, 1080, "Glitch - Graph Demo", glitch.WindowConfig{
-		Vsync: true,
+		Vsync:   true,
 		Samples: 4,
 	})
 	check(err)
@@ -34,13 +36,15 @@ func runGame() {
 	gui := debugui.NewImgui(win)
 
 	shader, err := glitch.NewShader(shaders.SpriteShader)
-	if err != nil { panic(err) }
+	if err != nil {
+		panic(err)
+	}
 
 	pass := glitch.NewRenderPass(shader)
 
 	dat := make([]glitch.Vec2, 0)
 	for i := 0; i < 1000; i++ {
-		dat = append(dat, glitch.Vec2{float64(i)/100.0, float64(math.Sin(float64(i) / 100.0))})
+		dat = append(dat, glitch.Vec2{float64(i) / 100.0, float64(math.Sin(float64(i) / 100.0))})
 	}
 
 	// lightBlue := glitch.RGBA{0x8a, 0xeb, 0xf1, 0xff}
@@ -50,7 +54,7 @@ func runGame() {
 	// rect := glitch.R(0 + pad, 0 + pad, 1920 - pad, 1080 - pad)
 	// rect := glitch.R(0, 0, 1, 1)
 	rect := win.Bounds()
-	rect = glitch.R(rect.Min[0], rect.Min[1], rect.Min[0] + 500, rect.Min[1] + 500)
+	rect = glitch.R(rect.Min[0], rect.Min[1], rect.Min[0]+500, rect.Min[1]+500)
 
 	graph := graph.NewGraph(rect)
 

--- a/examples/ui/main.go
+++ b/examples/ui/main.go
@@ -37,29 +37,42 @@ func main() {
 
 func runGame() {
 	win, err := glitch.NewWindow(1920, 1080, "Glitch UI Demo", glitch.WindowConfig{
-		Vsync: true,
+		Vsync:   true,
 		Samples: 0,
 	})
-	if err != nil { panic(err) }
+	if err != nil {
+		panic(err)
+	}
 
 	shader, err := glitch.NewShader(shaders.PixelArtShader)
-	if err != nil { panic(err) }
+	if err != nil {
+		panic(err)
+	}
 	pass := glitch.NewRenderPass(shader)
 	// pass.SoftwareSort = glitch.SoftwareSortY
 	// pass.DepthTest = true
 	// pass.DepthBump = true
 
 	buttonImage, err := loadImage("button.png")
-	if err != nil { panic(err) }
+	if err != nil {
+		panic(err)
+	}
 	buttonHoverImage, err := loadImage("button_hover.png")
-	if err != nil { panic(err) }
+	if err != nil {
+		panic(err)
+	}
 	buttonPressImage, err := loadImage("button_press.png")
-	if err != nil { panic(err) }
+	if err != nil {
+		panic(err)
+	}
 	panelImage, err := loadImage("panel.png")
-	if err != nil { panic(err) }
+	if err != nil {
+		panic(err)
+	}
 	panelInnerImage, err := loadImage("panel_inner.png")
-	if err != nil { panic(err) }
-
+	if err != nil {
+		panic(err)
+	}
 
 	scale := 4.0
 	texture := glitch.NewTexture(buttonImage, false)
@@ -85,7 +98,9 @@ func runGame() {
 
 	// Text
 	atlas, err := glitch.BasicFontAtlas()
-	if err != nil { panic(err) }
+	if err != nil {
+		panic(err)
+	}
 
 	screenScale := 1.5 // This is just a weird scaling number
 
@@ -98,10 +113,10 @@ func runGame() {
 
 	textStyle := ui.NewTextStyle().Scale(4)
 	buttonStyle := ui.Style{
-		Normal: ui.NewSpriteStyle(buttonSprite, glitch.White),
+		Normal:  ui.NewSpriteStyle(buttonSprite, glitch.White),
 		Hovered: ui.NewSpriteStyle(buttonHoverSprite, glitch.White),
 		Pressed: ui.NewSpriteStyle(buttonPressSprite, glitch.White),
-		Text: textStyle,
+		Text:    textStyle,
 	}
 
 	for !win.Closed() {
@@ -177,9 +192,6 @@ func runGame() {
 	}
 }
 
-
-
-
 // package main
 
 // import (
@@ -241,7 +253,6 @@ func runGame() {
 // 	if err != nil { panic(err) }
 // 	panelInnerImage, err := loadImage("panel_inner.png")
 // 	if err != nil { panic(err) }
-
 
 // 	texture := glitch.NewTexture(buttonImage, false)
 // 	buttonSprite := glitch.NewNinePanelSprite(texture, texture.Bounds(), glitch.R(1, 1, 1, 1))
@@ -336,4 +347,3 @@ func runGame() {
 // 		win.Update()
 // 	}
 // }
-

--- a/examples/web/Makefile
+++ b/examples/web/Makefile
@@ -2,8 +2,11 @@ all:
 	GOOS=js GOARCH=wasm go build -o gophermark.wasm github.com/unitoftime/glitch/examples/gophermark
 	GOOS=js GOARCH=wasm go build -ldflags "-s" -o frame.wasm github.com/unitoftime/glitch/examples/frame
 	GOOS=js GOARCH=wasm go build -ldflags "-s" -o ui.wasm github.com/unitoftime/glitch/examples/ui
-#	GOOS=js GOARCH=wasm go build -ldflags "-s" -o 3d.wasm github.com/unitoftime/glitch/examples/3d
+	GOOS=js GOARCH=wasm go build -ldflags "-s" -o 3d.wasm github.com/unitoftime/glitch/examples/3d
 	GOOS=js GOARCH=wasm go build -ldflags "-s" -o graph.wasm github.com/unitoftime/glitch/examples/graph
 
 
 #	tinygo build -o gophermark-tiny.wasm -target wasm github.com/unitoftime/glitch/examples/gophermark
+
+run: all
+	go run main.go

--- a/examples/web/main.go
+++ b/examples/web/main.go
@@ -7,5 +7,7 @@ import (
 
 func main() {
 	log.Println("Serving on 8081")
-	http.ListenAndServe(`:8081`, http.FileServer(http.Dir(`.`)))
+	if err := http.ListenAndServe(`:8081`, http.FileServer(http.Dir(`.`))); err != nil {
+		panic(err)
+	}
 }

--- a/examples/web/wasm_exec.js
+++ b/examples/web/wasm_exec.js
@@ -19,8 +19,8 @@
 				outputBuf += decoder.decode(buf);
 				const nl = outputBuf.lastIndexOf("\n");
 				if (nl != -1) {
-					console.log(outputBuf.substr(0, nl));
-					outputBuf = outputBuf.substr(nl + 1);
+					console.log(outputBuf.substring(0, nl));
+					outputBuf = outputBuf.substring(nl + 1);
 				}
 				return buf.length;
 			},
@@ -111,6 +111,10 @@
 			const setInt64 = (addr, v) => {
 				this.mem.setUint32(addr + 0, v, true);
 				this.mem.setUint32(addr + 4, Math.floor(v / 4294967296), true);
+			}
+
+			const setInt32 = (addr, v) => {
+				this.mem.setUint32(addr + 0, v, true);
 			}
 
 			const getInt64 = (addr) => {
@@ -206,7 +210,10 @@
 
 			const timeOrigin = Date.now() - performance.now();
 			this.importObject = {
-				go: {
+				_gotest: {
+					add: (a, b) => a + b,
+				},
+				gojs: {
 					// Go's SP does not change as long as no Go code is running. Some operations (e.g. calls, getters and setters)
 					// may synchronously trigger a Go event handler. This makes Go code get executed in the middle of the imported
 					// function. A goroutine can switch to a new stack if the current stack is too small (see morestack function).
@@ -269,7 +276,7 @@
 									this._resume();
 								}
 							},
-							getInt64(sp + 8) + 1, // setTimeout has been seen to fire up to 1 millisecond early
+							getInt64(sp + 8),
 						));
 						this.mem.setInt32(sp + 16, id, true);
 					},

--- a/internal/gl/gl_opengl.go
+++ b/internal/gl/gl_opengl.go
@@ -1,3 +1,4 @@
+//go:build !js
 // +build !js
 
 package gl
@@ -6,6 +7,7 @@ import (
 	"log"
 	"strings"
 	"unsafe"
+
 	// "math/f32"
 
 	//	"github.com/go-gl/gl/v2.1/gl"
@@ -455,6 +457,7 @@ func DeleteTexture(v Texture) {
 // DepthFunc sets the function used for depth buffer comparisons.
 //
 // Valid fn values:
+//
 //	NEVER
 //	LESS
 //	EQUAL
@@ -666,7 +669,7 @@ func GetIntegerv(pname Enum, data []int32) {
 //
 // http://www.khronos.org/opengles/sdk/docs/man3/html/glGet.xhtml
 func GetInteger(pname Enum) Object {
-// func GetInteger(pname Enum) int {
+	// func GetInteger(pname Enum) int {
 	var data int32
 	gl.GetIntegerv(uint32(pname), &data)
 	return Object{uint32(data)}
@@ -796,6 +799,7 @@ func GetShaderSource(s Shader) string {
 // GetString reports current GL state.
 //
 // Valid name values:
+//
 //	EXTENSIONS
 //	RENDERER
 //	SHADING_LANGUAGE_VERSION
@@ -1211,12 +1215,12 @@ func Uniform4f(dst Uniform, v0, v1, v2, v3 float32) {
 func Uniform4fv(dst Uniform, src []float32) {
 	gl.Uniform4fv(dst.Value, int32(len(src)/4), &src[0])
 }
+
 // func Uniform4fv(dst Uniform, src []float32) {
 // func Uniform4fv(dst Uniform, count int32, value *float32) {
 // 	gl.Uniform4fv(dst.Value, count, value)
 // 	// gl.Uniform4fv(dst.Value, int32(len(src)/4), &src[0])
 // }
-
 
 // Uniform4i writes an ivec4 uniform variable.
 //
@@ -1248,13 +1252,13 @@ func UniformMatrix2fv(dst Uniform, src []float32) {
 // Each matrix must be supplied in column major order.
 //
 // http://www.khronos.org/opengles/sdk/docs/man3/html/glUniform.xhtml
-// func UniformMatrix3fv(dst Uniform, src []float32) {
-// 	gl.UniformMatrix3fv(dst.Value, int32(len(src)/(3*3)), false, &src[0])
-// }
+//
+//	func UniformMatrix3fv(dst Uniform, src []float32) {
+//		gl.UniformMatrix3fv(dst.Value, int32(len(src)/(3*3)), false, &src[0])
+//	}
 func UniformMatrix3fv(dst Uniform, count int32, transpose bool, value *float32) {
 	gl.UniformMatrix3fv(dst.Value, count, transpose, value)
 }
-
 
 // UniformMatrix4fv writes 4x4 matrices. Each matrix uses 16
 // float32 values, so the number of matrices written is len(src)/16.

--- a/internal/gl/gl_opengles.go
+++ b/internal/gl/gl_opengles.go
@@ -2,7 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build darwin linux
+//go:build linux && (arm || arm64)
+// +build linux
 // +build arm arm64
 
 package gl

--- a/internal/gl/gl_webgl_wasm.go
+++ b/internal/gl/gl_webgl_wasm.go
@@ -37,9 +37,10 @@ var jsMemory js.Value
 var jsMemoryBuffer, jsMemoryFloat32, jsMemoryInt32, jsMemoryUint32 js.Value
 var jsMemoryBufferVec2, jsMemoryBufferVec3, jsMemoryBufferVec4 js.Value
 var jsMemoryBufferMat4 js.Value
+
 func init() {
 	// TODO: Reasonable default?
-	resizeJavascriptCopyBuffer(16*1024*1024)  // x * MB
+	resizeJavascriptCopyBuffer(16 * 1024 * 1024) // x * MB
 }
 
 func resizeJavascriptCopyBuffer(size int) {
@@ -73,49 +74,49 @@ var ContextWatcher contextWatcher
 type contextWatcher struct{}
 
 var (
-	fnBufferSubData js.Value
-	fnBufferData js.Value
-	fnBindVertexArray js.Value
-	fnCreateVertexArray js.Value
-	fnCreateBuffer js.Value
-	fnBindBuffer js.Value
-	fnBindTexture js.Value
-	fnGetAttribLocation js.Value
-	fnVertexAttribPointer js.Value
+	fnBufferSubData           js.Value
+	fnBufferData              js.Value
+	fnBindVertexArray         js.Value
+	fnCreateVertexArray       js.Value
+	fnCreateBuffer            js.Value
+	fnBindBuffer              js.Value
+	fnBindTexture             js.Value
+	fnGetAttribLocation       js.Value
+	fnVertexAttribPointer     js.Value
 	fnEnableVertexAttribArray js.Value
-	fnDeleteVertexArray js.Value
-	fnDeleteBuffer js.Value
-	fnDrawElements js.Value
+	fnDeleteVertexArray       js.Value
+	fnDeleteBuffer            js.Value
+	fnDrawElements            js.Value
 
-	fnEnable js.Value
+	fnEnable    js.Value
 	fnDepthFunc js.Value
-	fnDisable js.Value
+	fnDisable   js.Value
 
 	fnBindFramebuffer js.Value
 
 	fnUniformMatrix4fv js.Value
-	fnViewport js.Value
+	fnViewport         js.Value
 
-	fnClear js.Value
+	fnClear      js.Value
 	fnClearColor js.Value
 
 	fnUseProgram js.Value
 
 	fnFinish js.Value
-	fnFlush js.Value
+	fnFlush  js.Value
 
-	fnGetParameter js.Value
-	fnCreateFramebuffer js.Value
-	fnCreateProgram js.Value
-	fnCreateTexture js.Value
-	fnDeleteFramebuffer js.Value
-	fnDeleteShader js.Value
+	fnGetParameter         js.Value
+	fnCreateFramebuffer    js.Value
+	fnCreateProgram        js.Value
+	fnCreateTexture        js.Value
+	fnDeleteFramebuffer    js.Value
+	fnDeleteShader         js.Value
 	fnFramebufferTexture2D js.Value
-	fnGenerateMipmap js.Value
-	fnGetUniformLocation js.Value
-	fnLinkProgram js.Value
-	fnTexImage2D js.Value
-	fnTexSubImage2D js.Value
+	fnGenerateMipmap       js.Value
+	fnGetUniformLocation   js.Value
+	fnLinkProgram          js.Value
+	fnTexImage2D           js.Value
+	fnTexSubImage2D        js.Value
 )
 
 func (contextWatcher) OnMakeCurrent(context interface{}) {
@@ -131,7 +132,7 @@ func (contextWatcher) OnMakeCurrent(context interface{}) {
 		webgl1Mode = true
 	} else {
 		if strings.HasPrefix(versionStr, "WebGL 2.0") {
-		fmt.Println("Switching to WebGL 2.0 mode")
+			fmt.Println("Switching to WebGL 2.0 mode")
 			webgl1Mode = false
 		} else {
 			fmt.Println("Was unable to determine webgl mode from version string! Sticking with webgl1 mode!")
@@ -424,7 +425,7 @@ func BufferData(target Enum, size int, data any, usage Enum) {
 
 func BlitFramebuffer(srcX0 int32, srcY0 int32, srcX1 int32, srcY1 int32, dstX0 int32, dstY0 int32, dstX1 int32, dstY1 int32, mask uint32, filter uint32) {
 	panic("Not supported!") // TODO
-//	gl.BlitFrameBuffer(srcX0 int32, srcY0 int32, srcX1 int32, srcY1 int32, dstX0 int32, dstY0 int32, dstX1 int32, dstY1 int32, mask uint32, filter uint32)
+	// gl.BlitFrameBuffer(srcX0 int32, srcY0 int32, srcX1 int32, srcY1 int32, dstX0 int32, dstY0 int32, dstX1 int32, dstY1 int32, mask uint32, filter uint32)
 }
 
 // func PtrOffset(offset int) unsafe.Pointer {
@@ -452,7 +453,6 @@ func ReadBuffer(target Enum) {
 func PolygonMode(face, mode Enum) {
 	//	fmt.Println("Error: PolygonMode not supported in webgl")
 }
-
 
 func ActiveTexture(texture Enum) {
 	c.Call("activeTexture", int(texture))
@@ -784,7 +784,6 @@ func GetAttribLocation(p Program, name string) Attrib {
 // 	return Object{c.Call("getParameter", int(pname))}
 // }
 
-
 // func GetBufferParameteri(target, pname Enum) int {
 // 	return c.Call("getBufferParameter", int(target), int(pname)).Int()
 // }
@@ -1055,7 +1054,6 @@ func TexImage2DFull(target Enum, level int, format1 Enum, width, height int, for
 	}
 }
 
-
 func TexSubImage2D(target Enum, level int, x, y, width, height int, format, ty Enum, data []byte) {
 	array, length := byteSliceToTypedArray(data)
 	if !array.IsNull() {
@@ -1133,16 +1131,16 @@ func Uniform1fv(dst Uniform, src []float32) {
 // 	c.Call("uniform3f", dst.Value, v0, v1, v2)
 // }
 
-// func Uniform3fv(dst Uniform, src []float32) {
-// 	// c.Call("uniform3fv", dst.Value, src)
+func Uniform3fv(dst Uniform, src []float32) {
+	// c.Call("uniform3fv", dst.Value, src)
 
-// 	SliceToTypedArray(src)
-// 	c.Call("uniform3fv", dst.Value, jsMemoryBufferVec3)
+	// SliceToTypedArray(src)
+	// c.Call("uniform3fv", dst.Value, jsMemoryBufferVec3)
 
-// 	// array, length := SliceToTypedArray(src)
-// 	// subarray := array.Call("subarray", 0, length)
-// 	// c.Call("uniform3fv", dst.Value, subarray)
-// }
+	array, length := SliceToTypedArray(src)
+	subarray := array.Call("subarray", 0, length)
+	c.Call("uniform3fv", dst.Value, subarray)
+}
 
 // func Uniform3i(dst Uniform, v0, v1, v2 int32) {
 // 	c.Call("uniform3i", dst.Value, v0, v1, v2)
@@ -1156,16 +1154,16 @@ func Uniform1fv(dst Uniform, src []float32) {
 // 	c.Call("uniform4f", dst.Value, v0, v1, v2, v3)
 // }
 
-// func Uniform4fv(dst Uniform, src []float32) {
-// 	// c.Call("uniform4fv", dst.Value, src)
+func Uniform4fv(dst Uniform, src []float32) {
+	// c.Call("uniform4fv", dst.Value, src)
 
-// 	SliceToTypedArray(src)
-// 	c.Call("uniform3fv", dst.Value, jsMemoryBufferVec4)
+	// SliceToTypedArray(src)
+	// c.Call("uniform3fv", dst.Value, jsMemoryBufferVec4)
 
-// 	// array, length := SliceToTypedArray(src)
-// 	// subarray := array.Call("subarray", 0, length)
-// 	// c.Call("uniform4fv", dst.Value, subarray) // TODO - I think probably most uniforms need this
-// }
+	array, length := SliceToTypedArray(src)
+	subarray := array.Call("subarray", 0, length)
+	c.Call("uniform4fv", dst.Value, subarray) // TODO - I think probably most uniforms need this
+}
 
 // func Uniform4i(dst Uniform, v0, v1, v2, v3 int32) {
 // 	c.Call("uniform4i", dst.Value, v0, v1, v2, v3)

--- a/internal/gl/types_opengles.go
+++ b/internal/gl/types_opengles.go
@@ -2,7 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build darwin linux
+//go:build linux && (arm || arm64)
+// +build linux
 // +build arm arm64
 
 package gl

--- a/mesh.go
+++ b/mesh.go
@@ -1,23 +1,25 @@
 package glitch
 
+import "fmt"
+
 // For batching multiple sprites into one
 type Batch struct {
-	mesh *Mesh
-	material Material
+	mesh        *Mesh
+	material    Material
 	Translucent bool
 }
 
 func NewBatch() *Batch {
 	return &Batch{
-		mesh: NewMesh(),
+		mesh:     NewMesh(),
 		material: nil,
 	}
 }
 
 func (b *Batch) Buffer(pass *RenderPass) *Batch {
 	return &Batch{
-		mesh: b.mesh.Buffer(pass, b.material, b.Translucent),
-		material: b.material,
+		mesh:        b.mesh.Buffer(pass, b.material, b.Translucent),
+		material:    b.material,
 		Translucent: b.Translucent,
 	}
 }
@@ -41,7 +43,7 @@ func (b *Batch) Add(mesh *Mesh, matrix glMat4, mask RGBA, material Material, tra
 	// Append each index
 	currentElement := uint32(len(b.mesh.positions))
 	for i := range mesh.indices {
-		b.mesh.indices = append(b.mesh.indices, currentElement + mesh.indices[i])
+		b.mesh.indices = append(b.mesh.indices, currentElement+mesh.indices[i])
 	}
 
 	// Append each position
@@ -86,7 +88,6 @@ func (b *Batch) Add(mesh *Mesh, matrix glMat4, mask RGBA, material Material, tra
 	}
 	b.mesh.bounds = b.mesh.bounds.Union(newBounds)
 
-
 	if len(mesh.normals) > 0 {
 		renormalizeMat := matrix.Inv().Transpose()
 		for i := range mesh.normals {
@@ -123,7 +124,6 @@ func (b *Batch) Add(mesh *Mesh, matrix glMat4, mask RGBA, material Material, tra
 	// for i := range mesh.positions {
 	// 	posBuf[i] = mat.Apply(mesh.positions[i])
 	// }
-
 
 	// min := posBuf[0]
 	// max := posBuf[0]
@@ -216,6 +216,7 @@ func (b *Batch) DrawColorMask(target BatchTarget, matrix Mat4, color RGBA) {
 func (b *Batch) RectDraw(target BatchTarget, bounds Rect) {
 	b.RectDrawColorMask(target, bounds, RGBA{1, 1, 1, 1})
 }
+
 // TODO: Generalize this rectdraw logic. Copy paseted from Sprite
 func (b *Batch) RectDrawColorMask(target BatchTarget, bounds Rect, mask RGBA) {
 	// pass.SetTexture(0, s.texture)
@@ -223,7 +224,7 @@ func (b *Batch) RectDrawColorMask(target BatchTarget, bounds Rect, mask RGBA) {
 
 	batchBounds := b.Bounds().Rect()
 	matrix := Mat4Ident
-	matrix.Scale(bounds.W() / batchBounds.W(), bounds.H() / batchBounds.H(), 1).Translate(bounds.W()/2 + bounds.Min[0], bounds.H()/2 + bounds.Min[1], 0)
+	matrix.Scale(bounds.W()/batchBounds.W(), bounds.H()/batchBounds.H(), 1).Translate(bounds.W()/2+bounds.Min[0], bounds.H()/2+bounds.Min[1], 0)
 	target.Add(b.mesh, matrix.gl(), mask, b.material, false)
 }
 
@@ -233,11 +234,11 @@ func (b *Batch) Bounds() Box {
 
 type Mesh struct {
 	positions []glVec3
-	normals []glVec3
-	colors []glVec4
+	normals   []glVec3
+	colors    []glVec4
 	texCoords []glVec2
-	indices []uint32
-	bounds Box
+	indices   []uint32
+	bounds    Box
 
 	origin Vec3
 
@@ -248,10 +249,10 @@ type Mesh struct {
 func NewMesh() *Mesh {
 	return &Mesh{
 		positions: make([]glVec3, 0),
-		normals: make([]glVec3, 0),
-		colors: make([]glVec4, 0),
+		normals:   make([]glVec3, 0),
+		colors:    make([]glVec4, 0),
 		texCoords: make([]glVec2, 0),
-		indices: make([]uint32, 0),
+		indices:   make([]uint32, 0),
 	}
 }
 
@@ -292,7 +293,7 @@ func (m *Mesh) Bounds() Box {
 func (m *Mesh) Append(m2 *Mesh) {
 	currentElement := uint32(len(m.positions))
 	for i := range m2.indices {
-		m.indices = append(m.indices, currentElement + m2.indices[i])
+		m.indices = append(m.indices, currentElement+m2.indices[i])
 	}
 
 	m.positions = append(m.positions, m2.positions...)
@@ -306,7 +307,9 @@ func (m *Mesh) Append(m2 *Mesh) {
 // Changes the origin point of the mesh by translating all the geometry to the new origin. This shouldn't be called frequently
 // Returns a newly allocated mesh and does not modify the original
 func (originalMesh *Mesh) WithSetOrigin(newOrigin Vec3) *Mesh {
-	if originalMesh.origin == newOrigin { return originalMesh } // Skip if we've already translated this amount
+	if originalMesh.origin == newOrigin {
+		return originalMesh
+	} // Skip if we've already translated this amount
 	// delta := pos.Sub(m.translation)
 
 	newMesh := NewMesh()
@@ -375,7 +378,7 @@ func (m *Mesh) AppendQuadMesh(bounds Rect, uvBounds Rect, color RGBA) {
 
 	currentElement := uint32(len(m.positions))
 	for i := range inds {
-		m.indices = append(m.indices, currentElement + inds[i])
+		m.indices = append(m.indices, currentElement+inds[i])
 	}
 
 	m.positions = append(m.positions, positions...)
@@ -423,47 +426,47 @@ func NewQuadMesh(bounds Rect, uvBounds Rect) *Mesh {
 
 	return &Mesh{
 		positions: positions,
-		colors: colors,
+		colors:    colors,
 		texCoords: texCoords,
-		indices: inds,
-		bounds: bounds.ToBox(),
+		indices:   inds,
+		bounds:    bounds.ToBox(),
 	}
 }
 
 func NewCubeMesh(size float64) *Mesh {
-	f32size := float32(size/2)
+	f32size := float32(size / 2)
 
 	positions := []glVec3{
 		// Front face
-		glVec3{-f32size, -f32size,  f32size},
-		glVec3{f32size, -f32size,  f32size},
-		glVec3{f32size,  f32size,  f32size},
-		glVec3{-f32size,  f32size,  f32size},
+		glVec3{-f32size, -f32size, f32size},
+		glVec3{f32size, -f32size, f32size},
+		glVec3{f32size, f32size, f32size},
+		glVec3{-f32size, f32size, f32size},
 		// Back face
 		glVec3{-f32size, -f32size, -f32size},
-		glVec3{-f32size,  f32size, -f32size},
-		glVec3{f32size,  f32size, -f32size},
+		glVec3{-f32size, f32size, -f32size},
+		glVec3{f32size, f32size, -f32size},
 		glVec3{f32size, -f32size, -f32size},
 		// Top face
-		glVec3{-f32size,  f32size, -f32size},
-		glVec3{-f32size,  f32size,  f32size},
-		glVec3{f32size,  f32size,  f32size},
-		glVec3{f32size,  f32size, -f32size},
+		glVec3{-f32size, f32size, -f32size},
+		glVec3{-f32size, f32size, f32size},
+		glVec3{f32size, f32size, f32size},
+		glVec3{f32size, f32size, -f32size},
 		// Bottom face
 		glVec3{-f32size, -f32size, -f32size},
 		glVec3{f32size, -f32size, -f32size},
-		glVec3{f32size, -f32size,  f32size},
-		glVec3{-f32size, -f32size,  f32size},
+		glVec3{f32size, -f32size, f32size},
+		glVec3{-f32size, -f32size, f32size},
 		// Right face
 		glVec3{f32size, -f32size, -f32size},
-		glVec3{f32size,  f32size, -f32size},
-		glVec3{f32size,  f32size,  f32size},
-		glVec3{f32size, -f32size,  f32size},
+		glVec3{f32size, f32size, -f32size},
+		glVec3{f32size, f32size, f32size},
+		glVec3{f32size, -f32size, f32size},
 		// Left face
 		glVec3{-f32size, -f32size, -f32size},
-		glVec3{-f32size, -f32size,  f32size},
-		glVec3{-f32size,  f32size,  f32size},
-		glVec3{-f32size,  f32size, -f32size},
+		glVec3{-f32size, -f32size, f32size},
+		glVec3{-f32size, f32size, f32size},
+		glVec3{-f32size, f32size, -f32size},
 	}
 
 	col := glVec4{1.0, 1.0, 1.0, 1.0}
@@ -514,18 +517,18 @@ func NewCubeMesh(size float64) *Mesh {
 		// Front face
 		glVec2{-0, -0},
 		glVec2{0, -0},
-		glVec2{0,  0},
-		glVec2{-0,  0},
+		glVec2{0, 0},
+		glVec2{-0, 0},
 		// Back face
 		glVec2{-0, -0},
-		glVec2{-0,  0},
-		glVec2{0,  0},
+		glVec2{-0, 0},
+		glVec2{0, 0},
 		glVec2{0, -0},
 		// Top face
-		glVec2{-0,  0},
-		glVec2{-0,  0},
-		glVec2{0,  0},
-		glVec2{0,  0},
+		glVec2{-0, 0},
+		glVec2{-0, 0},
+		glVec2{0, 0},
+		glVec2{0, 0},
 		// Bottom face
 		glVec2{-0, -0},
 		glVec2{0, -0},
@@ -533,37 +536,38 @@ func NewCubeMesh(size float64) *Mesh {
 		glVec2{-0, -0},
 		// Right face
 		glVec2{0, -0},
-		glVec2{0,  0},
-		glVec2{0,  0},
+		glVec2{0, 0},
+		glVec2{0, 0},
 		glVec2{0, -0},
 		// Left face
 		glVec2{-0, -0},
 		glVec2{-0, -0},
-		glVec2{-0,  0},
-		glVec2{-0,  0},
+		glVec2{-0, 0},
+		glVec2{-0, 0},
 	}
 
 	indices := []uint32{
-		0,  1,  2,      0,  2,  3,    // front
-    4,  5,  6,      4,  6,  7,    // back
-    8,  9,  10,     8,  10, 11,   // top
-    12, 13, 14,     12, 14, 15,   // bottom
-    16, 17, 18,     16, 18, 19,   // right
-    20, 21, 22,     20, 22, 23,   // left
+		0, 1, 2, 0, 2, 3, // front
+		4, 5, 6, 4, 6, 7, // back
+		8, 9, 10, 8, 10, 11, // top
+		12, 13, 14, 12, 14, 15, // bottom
+		16, 17, 18, 16, 18, 19, // right
+		20, 21, 22, 20, 22, 23, // left
 	}
 
 	return &Mesh{
 		positions: positions,
-		normals: normals,
-		colors: colors,
+		normals:   normals,
+		colors:    colors,
 		texCoords: texCoords,
-		indices: indices,
+		indices:   indices,
 		bounds: Box{
 			Min: Vec3{-size, -size, -size},
 			Max: Vec3{size, size, size},
 		},
 	}
 }
+
 //--------------------------------------------------------------------------------
 
 func (m *Mesh) GetBuffer() *VertexBuffer {
@@ -593,7 +597,7 @@ func batchToBuffers(shader *Shader, mesh *Mesh, mat32 glMat4, mask RGBA) {
 	for bufIdx, attr := range shader.attrFmt {
 		// TODO - I'm not sure of a good way to break up this switch statement
 		switch attr.Swizzle {
-			// Positions
+		// Positions
 		case PositionXY:
 			posBuf := *(destBuffs[bufIdx]).(*[]glVec2)
 			if mat32 == glMat4Ident {
@@ -632,15 +636,15 @@ func batchToBuffers(shader *Shader, mesh *Mesh, mat32 glMat4, mask RGBA) {
 			// 	}
 
 			// TODO: Re enable when you have funcs like inv(), transpose() on glMat4
-		// case NormalXYZ:
-		// 	renormalizeMat := c.matrix.Inv().Transpose().gl()
-		// 	normBuf := *(destBuffs[bufIdx]).(*[]glVec3)
-		// 	for i := range mesh.normals {
-		// 		vec := renormalizeMat.Apply(mesh.normals[i])
-		// 		normBuf[i] = vec
-		// 	}
+		case NormalXYZ:
+			// renormalizeMat := mat32.Inv().Transpose()
+			normBuf := *(destBuffs[bufIdx]).(*[]glVec3)
+			for i := range mesh.normals {
+				vec := mesh.normals[i]
+				normBuf[i] = vec
+			}
 
-			// Colors
+		// Colors
 		case ColorR:
 			colBuf := *(destBuffs[bufIdx]).(*[]float32)
 			for i := range mesh.colors {
@@ -680,7 +684,7 @@ func batchToBuffers(shader *Shader, mesh *Mesh, mat32 glMat4, mask RGBA) {
 				texBuf[i] = mesh.texCoords[i]
 			}
 		default:
-			panic("Unsupported")
+			panic(fmt.Sprintf("Unsupported %T: %+v", attr, attr))
 		}
 	}
 


### PR DESCRIPTION
Fixes the examples, allows building of the `3d` example on OS X by setting build flags on `internal/gl` files such that `darwin` builds resolve from the `_wasm` files/funcs.